### PR TITLE
feat: Add threading support for IO-bound tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ pyproc is **NOT** designed for:
 - **Minimal Overhead** - 45μs p50 latency, 200,000+ req/s with 8 workers
 - **Production Ready** - Health checks, graceful shutdown, automatic restarts
 - **Easy Deployment** - Single binary + Python scripts, no service mesh needed
+- **IO-Bound Support** - Optional multi-threading for concurrent IO operations
 
 ## 🚀 Quick Start (5 minutes)
 
@@ -218,6 +219,38 @@ poolCfg := pyproc.PoolConfig{
     MaxInFlight:    10,                   // Max concurrent requests per worker
     HealthInterval: 30 * time.Second,     // Health check frequency
 }
+```
+
+#### IO-Bound Task Configuration (New!)
+For IO-bound workloads (network requests, database queries), enable threading:
+
+```go
+// Enable multi-threading for IO-bound tasks
+poolOpts := pyproc.PoolOptions{
+    Config: poolCfg,
+    WorkerConfig: pyproc.WorkerConfig{
+        // ... other config ...
+        WorkerConcurrency: 4,  // Enable 4 threads per worker
+    },
+}
+```
+
+Python worker with threading:
+```python
+from pyproc_worker import expose, run_worker
+import time
+import requests
+
+@expose
+def fetch_data(req):
+    """IO-bound operation - benefits from threading"""
+    url = req["url"]
+    response = requests.get(url)  # Thread releases GIL during I/O
+    return {"status": response.status_code, "data": response.json()}
+
+if __name__ == "__main__":
+    # Concurrency is set by Go side via PYPROC_WORKER_CONCURRENCY
+    run_worker()
 ```
 
 ### Python Worker Development

--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,11 @@ python:
   # Worker script path
   worker_script: "./worker.py"
   
+  # Worker concurrency (threads per worker process)
+  # 1 = single-threaded (default, best for CPU-bound tasks)
+  # > 1 = multi-threaded (for IO-bound tasks)
+  worker_concurrency: 1
+  
   # Environment variables for Python process
   env:
     PYTHONUNBUFFERED: "1"

--- a/docs/design.md
+++ b/docs/design.md
@@ -78,6 +78,14 @@ semaphore := make(chan struct{}, workers * maxInFlight)
 - Process liveness verification
 - Automatic restart on failure (configurable)
 
+### IO-Bound Concurrency
+
+- Python workers now accept multiple socket connections in parallel.
+- `WorkerConcurrency` controls the number of threads servicing requests per process.
+- Each connection maintains request ordering while enabling overlapping IO waits.
+- Go pools require no API change; set the concurrency field in `WorkerConfig`.
+- Use the IO-bound worker example to validate throughput before production rollout.
+
 ## Protocol Specification
 
 ### Framing Protocol

--- a/examples/io_bound/README.md
+++ b/examples/io_bound/README.md
@@ -1,0 +1,81 @@
+# IO-Bound Tasks Example
+
+This example demonstrates how to use pyproc with multi-threaded Python workers to efficiently handle IO-bound tasks.
+
+## Overview
+
+When dealing with IO-bound operations (network requests, database queries, file I/O), Python's GIL (Global Interpreter Lock) doesn't significantly impact performance since threads release the GIL during I/O operations. This makes threading an effective solution for concurrent IO-bound tasks.
+
+## Features
+
+- **Multi-threaded Workers**: Each Python worker process can handle multiple requests concurrently using threads
+- **Configurable Concurrency**: Set the number of threads per worker via `WorkerConcurrency` field
+- **Efficient Resource Usage**: Better utilization of worker processes for IO-bound workloads
+
+## Configuration
+
+Key configuration for IO-bound tasks:
+
+```go
+WorkerConfig: pyproc.WorkerConfig{
+    WorkerConcurrency: 4, // 4 threads per worker process
+}
+```
+
+## Running the Example
+
+1. Make sure you have Python 3 installed
+2. Run the example:
+
+```bash
+cd examples/io_bound
+go run main.go
+```
+
+## What This Example Demonstrates
+
+1. **Concurrent API Fetches**: Multiple simulated HTTP requests running in parallel
+2. **Batch Operations**: Processing multiple URLs in a single request
+3. **Mixed IO Operations**: Different types of IO operations running concurrently
+4. **Performance Comparison**: Shows the speedup achieved with threading
+
+## When to Use Threading
+
+Use multi-threading (`WorkerConcurrency > 1`) when:
+- Your workload is IO-bound (network, database, file operations)
+- Requests spend significant time waiting for external resources
+- You want to maximize throughput for concurrent requests
+
+Keep single-threaded (`WorkerConcurrency = 1`) when:
+- Your workload is CPU-bound (heavy computation)
+- Operations don't involve waiting for external resources
+- You need predictable, sequential processing
+
+## Performance Benefits
+
+For IO-bound tasks, threading can provide significant performance improvements:
+- 8 requests × 1 second each = 8 seconds sequential → ~2 seconds concurrent (4x speedup)
+- Better resource utilization as threads wait for I/O
+- Reduced overall latency for batch operations
+
+## Architecture
+
+```
+┌─────────────┐
+│   Go App    │
+└──────┬──────┘
+       │
+   ┌───▼───┐
+   │ Pool  │
+   └───┬───┘
+       │
+   ┌───▼────────────────┐
+   │ Worker Process 1   │
+   │ ┌────────────────┐ │
+   │ │ Thread Pool    │ │
+   │ │ (4 threads)    │ │
+   │ └────────────────┘ │
+   └────────────────────┘
+```
+
+Each worker process maintains a thread pool, allowing multiple requests to be processed concurrently within the same process.

--- a/examples/io_bound/main.go
+++ b/examples/io_bound/main.go
@@ -1,0 +1,195 @@
+// Package main demonstrates IO-bound task handling with pyproc.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/YuminosukeSato/pyproc/pkg/pyproc"
+)
+
+func main() {
+	// Create pool configuration with multi-threading enabled
+	poolOpts := pyproc.PoolOptions{
+		Config: pyproc.PoolConfig{
+			Workers:        2,  // Number of worker processes
+			MaxInFlight:    10, // Max concurrent requests per worker
+			StartTimeout:   5 * time.Second,
+			HealthInterval: 30 * time.Second,
+		},
+		WorkerConfig: pyproc.WorkerConfig{
+			SocketPath:        "/tmp/pyproc-io-bound",
+			PythonExec:        "python3",
+			WorkerScript:      "./worker.py",
+			StartTimeout:      5 * time.Second,
+			WorkerConcurrency: 4, // Enable 4 threads per worker for IO-bound tasks
+		},
+	}
+
+	// Create and start the pool
+	pool, err := pyproc.NewPool(poolOpts, nil)
+	if err != nil {
+		log.Fatalf("Failed to create pool: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pool.Start(ctx); err != nil {
+		log.Fatalf("Failed to start pool: %v", err)
+	}
+	defer func() {
+		if err := pool.Shutdown(ctx); err != nil {
+			log.Printf("Failed to shutdown pool: %v", err)
+		}
+	}()
+
+	fmt.Println("=== IO-Bound Example ===")
+	fmt.Println("This example demonstrates handling multiple IO-bound requests concurrently")
+	fmt.Println("Each worker process has 4 threads to handle requests in parallel")
+	fmt.Println()
+
+	// Example 1: Concurrent fetch operations
+	fmt.Println("Example 1: Simulating concurrent API fetches...")
+	demonstrateConcurrentFetches(ctx, pool)
+
+	// Example 2: Batch operations
+	fmt.Println("\nExample 2: Simulating batch API operations...")
+	demonstrateBatchOperations(ctx, pool)
+
+	// Example 3: Mixed IO operations
+	fmt.Println("\nExample 3: Simulating mixed IO operations...")
+	demonstrateMixedOperations(ctx, pool)
+
+	// Example 4: Performance comparison
+	fmt.Println("\nExample 4: Performance comparison (sequential vs concurrent)...")
+	demonstratePerformance(ctx, pool)
+}
+
+func demonstrateConcurrentFetches(ctx context.Context, pool *pyproc.Pool) {
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	// Launch 8 concurrent requests
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			req := map[string]interface{}{
+				"url":   fmt.Sprintf("http://api%d.example.com", id),
+				"delay": 1.0, // Each request takes 1 second
+			}
+
+			var result map[string]interface{}
+			err := pool.Call(ctx, "fetch_remote_data", req, &result)
+			if err != nil {
+				log.Printf("Request %d failed: %v", id, err)
+				return
+			}
+			fmt.Printf("  Request %d completed on thread %v\n", id, result["thread_id"])
+		}(i)
+	}
+
+	wg.Wait()
+	fmt.Printf("  Total time for 8 requests (1s each): %.2fs\n", time.Since(start).Seconds())
+	fmt.Println("  (With threading, these run concurrently instead of taking 8s)")
+}
+
+func demonstrateBatchOperations(ctx context.Context, pool *pyproc.Pool) {
+	req := map[string]interface{}{
+		"urls": []string{
+			"http://api1.com",
+			"http://api2.com",
+			"http://api3.com",
+			"http://api4.com",
+			"http://api5.com",
+		},
+		"delay": 0.5,
+	}
+
+	start := time.Now()
+	var result map[string]interface{}
+	err := pool.Call(ctx, "batch_fetch", req, &result)
+	if err != nil {
+		log.Printf("Batch fetch failed: %v", err)
+		return
+	}
+	fmt.Printf("  Fetched %v URLs in %.2fs on thread %v\n",
+		result["total_urls"],
+		time.Since(start).Seconds(),
+		result["thread_id"])
+}
+
+func demonstrateMixedOperations(ctx context.Context, pool *pyproc.Pool) {
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	// Mix of different IO operations
+	operations := []struct {
+		method string
+		req    map[string]interface{}
+	}{
+		{"database_query", map[string]interface{}{"query": "SELECT * FROM orders", "delay": 0.3}},
+		{"fetch_remote_data", map[string]interface{}{"url": "http://api.example.com", "delay": 0.5}},
+		{"heavy_io_operation", map[string]interface{}{"steps": 3, "delay": 0.2}},
+		{"database_query", map[string]interface{}{"query": "UPDATE users SET active=true", "delay": 0.4}},
+	}
+
+	for i, op := range operations {
+		wg.Add(1)
+		go func(id int, method string, req map[string]interface{}) {
+			defer wg.Done()
+
+			var result map[string]interface{}
+			err := pool.Call(ctx, method, req, &result)
+			if err != nil {
+				log.Printf("Operation %d (%s) failed: %v", id, method, err)
+				return
+			}
+			fmt.Printf("  Operation %d (%s) completed on thread %v\n", id, method, result["thread_id"])
+		}(i, op.method, op.req)
+	}
+
+	wg.Wait()
+	fmt.Printf("  Mixed operations completed in %.2fs\n", time.Since(start).Seconds())
+}
+
+func demonstratePerformance(ctx context.Context, pool *pyproc.Pool) {
+	numRequests := 20
+	requestDelay := 0.2 // 200ms per request
+
+	// Sequential simulation (what it would be without threading)
+	sequentialTime := float64(numRequests) * requestDelay
+	fmt.Printf("  Expected sequential time for %d requests: %.2fs\n", numRequests, sequentialTime)
+
+	// Actual concurrent execution
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			req := map[string]interface{}{
+				"query": fmt.Sprintf("SELECT * FROM table_%d", id),
+				"delay": requestDelay,
+			}
+
+			var result map[string]interface{}
+			err := pool.Call(ctx, "database_query", req, &result)
+			if err != nil {
+				log.Printf("Query %d failed: %v", id, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	actualTime := time.Since(start).Seconds()
+
+	fmt.Printf("  Actual concurrent time: %.2fs\n", actualTime)
+	fmt.Printf("  Speedup: %.2fx faster\n", sequentialTime/actualTime)
+	fmt.Printf("  Time saved: %.2fs\n", sequentialTime-actualTime)
+}

--- a/examples/io_bound/worker.py
+++ b/examples/io_bound/worker.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+IO-Bound example worker demonstrating concurrent request handling.
+
+This example simulates IO-bound operations like HTTP requests or database queries
+by using time.sleep() to represent waiting for external resources.
+"""
+
+import os
+import sys
+import time
+import random
+from datetime import datetime
+import threading
+
+# Add parent directory to path to import pyproc_worker
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../worker/python"))
+
+from pyproc_worker import expose, run_worker
+
+
+@expose
+def fetch_remote_data(request):
+    """Simulate fetching data from a remote API."""
+    url = request.get("url", "http://example.com/api")
+    delay = request.get("delay", 1.0)
+    
+    # Log thread info to show concurrent execution
+    thread_id = threading.get_ident()
+    print(f"[Thread {thread_id}] Starting fetch from {url} at {datetime.now().isoformat()}")
+    
+    # Simulate network delay
+    time.sleep(delay)
+    
+    # Simulate response data
+    data = {
+        "url": url,
+        "status": 200,
+        "data": {
+            "items": random.randint(10, 100),
+            "timestamp": datetime.now().isoformat()
+        },
+        "thread_id": thread_id,
+        "duration": delay
+    }
+    
+    print(f"[Thread {thread_id}] Completed fetch from {url} at {datetime.now().isoformat()}")
+    return data
+
+
+@expose
+def batch_fetch(request):
+    """Simulate fetching data from multiple endpoints."""
+    urls = request.get("urls", ["http://api1.com", "http://api2.com", "http://api3.com"])
+    delay_per_url = request.get("delay", 0.5)
+    
+    thread_id = threading.get_ident()
+    print(f"[Thread {thread_id}] Starting batch fetch of {len(urls)} URLs")
+    
+    results = []
+    for url in urls:
+        # Simulate fetching each URL
+        time.sleep(delay_per_url)
+        results.append({
+            "url": url,
+            "status": 200,
+            "data": {"count": random.randint(1, 50)}
+        })
+    
+    return {
+        "total_urls": len(urls),
+        "results": results,
+        "thread_id": thread_id,
+        "total_duration": delay_per_url * len(urls)
+    }
+
+
+@expose
+def database_query(request):
+    """Simulate a database query operation."""
+    query = request.get("query", "SELECT * FROM users")
+    delay = request.get("delay", 0.3)
+    
+    thread_id = threading.get_ident()
+    print(f"[Thread {thread_id}] Executing query: {query}")
+    
+    # Simulate query execution
+    time.sleep(delay)
+    
+    # Simulate query results
+    rows = random.randint(5, 20)
+    return {
+        "query": query,
+        "rows_affected": rows,
+        "execution_time": delay,
+        "thread_id": thread_id
+    }
+
+
+@expose
+def heavy_io_operation(request):
+    """Simulate a heavy IO operation with multiple steps."""
+    steps = request.get("steps", 3)
+    delay_per_step = request.get("delay", 0.5)
+    
+    thread_id = threading.get_ident()
+    print(f"[Thread {thread_id}] Starting heavy IO operation with {steps} steps")
+    
+    results = []
+    for i in range(steps):
+        print(f"[Thread {thread_id}] Processing step {i+1}/{steps}")
+        time.sleep(delay_per_step)
+        results.append({
+            "step": i + 1,
+            "status": "completed",
+            "data": random.randint(100, 1000)
+        })
+    
+    return {
+        "steps_completed": steps,
+        "results": results,
+        "total_duration": steps * delay_per_step,
+        "thread_id": thread_id
+    }
+
+
+if __name__ == "__main__":
+    # Get socket path from environment or command line
+    socket_path = os.environ.get("PYPROC_SOCKET_PATH")
+    if not socket_path and len(sys.argv) > 1:
+        socket_path = sys.argv[1]
+    
+    # Get concurrency from environment (set by Go side)
+    concurrency = int(os.environ.get("PYPROC_WORKER_CONCURRENCY", "4"))
+    
+    print(f"Starting IO-bound worker with concurrency={concurrency}")
+    print("This worker demonstrates handling multiple IO-bound requests concurrently")
+    print("Each request simulates network/database latency using time.sleep()")
+    
+    # Run worker with specified concurrency
+    run_worker(socket_path, concurrency=concurrency)

--- a/pkg/pyproc/config.go
+++ b/pkg/pyproc/config.go
@@ -38,9 +38,10 @@ type RestartConfig struct {
 
 // PythonConfig defines Python runtime settings
 type PythonConfig struct {
-	Executable   string            `mapstructure:"executable"`
-	WorkerScript string            `mapstructure:"worker_script"`
-	Env          map[string]string `mapstructure:"env"`
+	Executable        string            `mapstructure:"executable"`
+	WorkerScript      string            `mapstructure:"worker_script"`
+	Env               map[string]string `mapstructure:"env"`
+	WorkerConcurrency int               `mapstructure:"worker_concurrency"`
 }
 
 // SocketConfig defines Unix domain socket settings
@@ -135,6 +136,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("python.env", map[string]string{
 		"PYTHONUNBUFFERED": "1",
 	})
+	v.SetDefault("python.worker_concurrency", 1) // Default to single-threaded for backward compatibility
 
 	// Socket defaults
 	v.SetDefault("socket.dir", "/tmp")

--- a/pkg/pyproc/pool_test.go
+++ b/pkg/pyproc/pool_test.go
@@ -2,6 +2,7 @@ package pyproc
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -318,5 +319,81 @@ func TestPoolHealthCheck(t *testing.T) {
 	}
 	if health.HealthyWorkers != opts.Config.Workers {
 		t.Errorf("expected %d healthy workers, got %d", opts.Config.Workers, health.HealthyWorkers)
+	}
+}
+
+func TestIOBoundConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping IO-bound concurrency test in short mode")
+	}
+
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:     1,
+			MaxInFlight: 4,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath:        "/tmp/test-io-concurrency.sock",
+			PythonExec:        "python3",
+			WorkerScript:      "../../examples/io_bound/worker.py",
+			StartTimeout:      5 * time.Second,
+			WorkerConcurrency: 4,
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+	defer func() { _ = pool.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start failed: %v", err)
+	}
+
+	numRequests := 4
+	errCh := make(chan error, numRequests)
+	var wg sync.WaitGroup
+	wg.Add(numRequests)
+
+	start := time.Now()
+
+	for i := 0; i < numRequests; i++ {
+		go func(idx int) {
+			defer wg.Done()
+
+			input := map[string]interface{}{
+				"url":   fmt.Sprintf("http://example.com/%d", idx),
+				"delay": 1.0,
+			}
+			var output map[string]interface{}
+
+			callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+
+			if err := pool.Call(callCtx, "fetch_remote_data", input, &output); err != nil {
+				errCh <- err
+				return
+			}
+
+			if _, ok := output["thread_id"]; !ok {
+				errCh <- fmt.Errorf("missing thread_id in response: %v", output)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("IO-bound call failed: %v", err)
+		}
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > 3*time.Second {
+		t.Fatalf("expected IO-bound concurrency to finish within 3s, took %v", elapsed)
 	}
 }

--- a/pkg/pyproc/worker.go
+++ b/pkg/pyproc/worker.go
@@ -27,12 +27,13 @@ const (
 
 // WorkerConfig defines configuration for a single worker
 type WorkerConfig struct {
-	ID           string
-	SocketPath   string
-	PythonExec   string
-	WorkerScript string
-	Env          map[string]string
-	StartTimeout time.Duration
+	ID                string
+	SocketPath        string
+	PythonExec        string
+	WorkerScript      string
+	Env               map[string]string
+	StartTimeout      time.Duration
+	WorkerConcurrency int
 }
 
 // Worker represents a single Python worker process
@@ -96,6 +97,9 @@ func (w *Worker) Start(ctx context.Context) error {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PYPROC_SOCKET_PATH=%s", w.cfg.SocketPath))
+	if w.cfg.WorkerConcurrency > 0 {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("PYPROC_WORKER_CONCURRENCY=%d", w.cfg.WorkerConcurrency))
+	}
 
 	// Capture output for debugging
 	cmd.Stdout = os.Stdout

--- a/worker/python/pyproc_worker/__init__.py
+++ b/worker/python/pyproc_worker/__init__.py
@@ -12,7 +12,10 @@ import os
 import socket
 import struct
 import sys
+import threading
 import traceback
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Callable
 
@@ -54,15 +57,11 @@ class FramedConnection:
 
     def read_message(self) -> bytes | None:
         """Read a framed message from the socket."""
-        # Read 4-byte length header
         length_bytes = self._read_exact(4)
         if not length_bytes:
             return None
 
-        # Parse length (big-endian)
         length = struct.unpack(">I", length_bytes)[0]
-
-        # Read message body
         message = self._read_exact(length)
         if not message:
             msg = "Failed to read complete message"
@@ -72,20 +71,17 @@ class FramedConnection:
 
     def write_message(self, data: bytes) -> None:
         """Write a framed message to the socket."""
-        # Write 4-byte length header (big-endian)
         length = len(data)
         self.conn.sendall(struct.pack(">I", length))
-
-        # Write message body
         self.conn.sendall(data)
 
-    def _read_exact(self, n: int) -> bytes | None:
-        """Read exactly n bytes from the socket."""
+    def _read_exact(self, num_bytes: int) -> bytes | None:
+        """Read exactly num_bytes from the socket."""
         data = b""
-        while len(data) < n:
-            chunk = self.conn.recv(n - len(data))
+        while len(data) < num_bytes:
+            chunk = self.conn.recv(num_bytes - len(data))
             if not chunk:
-                return None if len(data) == 0 else data
+                return data if data else None
             data += chunk
         return data
 
@@ -93,59 +89,84 @@ class FramedConnection:
 class Worker:
     """Main worker class that handles requests from Go."""
 
-    def __init__(self, socket_path: str, codec_type: str = "auto") -> None:
+    def __init__(self, socket_path: str, codec_type: str = "auto", concurrency: int = 1) -> None:
         self.socket_path = socket_path
-        self.codec = get_codec(codec_type)
-        self.conn = None
-        self.framed_conn = None
+        self.codec_type = codec_type
+        codec_preview = get_codec(codec_type)
+        self.codec_name = codec_preview.name
         self.tracing = get_tracing()
         self.cancellation_manager = CancellationManager()
-        logger.info("Using codec: %s", self.codec.name)
+        self.concurrency = max(1, concurrency)
+        self._shutdown = threading.Event()
+        self._connection_executor: ThreadPoolExecutor | None = None
+
+        if self.concurrency > 1:
+            self._connection_executor = ThreadPoolExecutor(
+                max_workers=self.concurrency,
+                thread_name_prefix="pyproc-worker",
+            )
+            logger.info("Using threaded mode with %d workers", self.concurrency)
+
+        logger.info("Using codec: %s", self.codec_name)
 
     def start(self) -> None:
         """Start the worker and listen for requests."""
-        # Remove socket file if it exists
         socket_file = Path(self.socket_path)
         if socket_file.exists():
             socket_file.unlink()
 
-        # Create Unix domain socket
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.bind(self.socket_path)
-        sock.listen(1)
+        sock.listen(self.concurrency)
+        sock.settimeout(1.0)
 
         logger.info("Worker listening on %s", self.socket_path)
 
-        while True:
-            try:
-                # Accept connection
-                conn, _ = sock.accept()
-                self.conn = conn
-                self.framed_conn = FramedConnection(conn, self.codec)
+        try:
+            while not self._shutdown.is_set():
+                try:
+                    conn, _ = sock.accept()
+                except socket.timeout:
+                    continue
+                except OSError as exc:
+                    if self._shutdown.is_set():
+                        break
+                    logger.error("Socket accept error: %s", exc)
+                    continue
 
-                logger.info("Accepted connection")
+                if self._connection_executor:
+                    try:
+                        self._connection_executor.submit(self._handle_connection, conn)
+                    except RuntimeError:
+                        with suppress(Exception):
+                            conn.close()
+                else:
+                    self._handle_connection(conn)
 
-                # Handle requests on this connection
-                self._handle_connection()
+        except KeyboardInterrupt:
+            logger.info("Worker shutting down")
+        finally:
+            self._shutdown.set()
+            with suppress(Exception):
+                sock.close()
+            if self._connection_executor:
+                self._connection_executor.shutdown(wait=True)
 
-            except KeyboardInterrupt:
-                logger.info("Worker shutting down")
-                break
-            except Exception:
-                logger.exception("Connection error")
-                if self.conn:
-                    self.conn.close()
+    def _create_codec(self) -> Codec:
+        """Create a new codec instance for the connection."""
+        return get_codec(self.codec_type)
 
-    def _handle_connection(self) -> None:
-        """Handle requests on the current connection."""
-        current_request_id = None
-        while True:
-            try:
-                # Read message
-                message = self.framed_conn.read_message()
+    def _handle_connection(self, conn: socket.socket) -> None:
+        """Serve a single connection until it is closed."""
+        codec = self._create_codec()
+        framed_conn = FramedConnection(conn, codec)
+        current_request_id: int | None = None
+
+        try:
+            while not self._shutdown.is_set():
+                message = framed_conn.read_message()
                 if not message:
                     logger.info("Connection closed by client")
-                    # If we have an active request, mark it as cancelled
                     if current_request_id is not None:
                         self.cancellation_manager.cancel_request(
                             current_request_id,
@@ -154,59 +175,62 @@ class Worker:
                         current_request_id = None
                     break
 
-                # Parse message
-                msg_data = self.framed_conn.codec.decode(message)
+                msg_data = framed_conn.codec.decode(message)
 
-                # Check if it's a wrapped message with type
-                if isinstance(msg_data, dict) and "type" in msg_data:
-                    msg_type = msg_data.get("type")
-                    payload = msg_data.get("payload", {})
+                request = self._extract_request(msg_data)
+                if request is None:
+                    continue
 
-                    if msg_type == "cancellation":
-                        # Handle cancellation message
-                        self._handle_cancellation(payload)
-                        continue  # No response needed for cancellation
-                    if msg_type == "request":
-                        request = payload
-                    else:
-                        logger.warning(f"Unknown message type: {msg_type}")
-                        continue
-                else:
-                    # Legacy format - treat as request
-                    request = msg_data
+                logger.debug("Received request: %s", request)
 
-                logger.debug(f"Received request: {request}")
-
-                # Track current request ID for cancellation
                 current_request_id = request.get("id", 0)
-
-                # Process request
                 response = self._process_request(request)
-
-                # Clear current request ID after processing
                 current_request_id = None
 
-                # Send response in legacy format for now
-                # NOTE: Will switch to wrapped format once Go side is updated
-                response_bytes = self.framed_conn.codec.encode(response)
-                self.framed_conn.write_message(response_bytes)
+                response_bytes = framed_conn.codec.encode(response)
+                framed_conn.write_message(response_bytes)
 
-            except BrokenPipeError:
-                # Connection closed due to cancellation - this is expected behavior
-                logger.debug(
-                    "Connection closed by client during response (likely due to cancellation)",
-                )
-                break
-            except Exception as e:
-                logger.exception("Error handling request")
-                # Try to send error response
-                try:
-                    error_response = {"id": 0, "ok": False, "error": str(e)}
-                    response_bytes = self.framed_conn.codec.encode(error_response)
-                    self.framed_conn.write_message(response_bytes)
-                except Exception:  # noqa: S110
-                    pass
-                break
+        except BrokenPipeError:
+            logger.debug(
+                "Connection closed by client during response (likely due to cancellation)",
+            )
+        except Exception as exc:
+            logger.exception("Error handling request")
+            try:
+                error_response = {"id": current_request_id or 0, "ok": False, "error": str(exc)}
+                response_bytes = framed_conn.codec.encode(error_response)
+                framed_conn.write_message(response_bytes)
+            except Exception:
+                logger.debug("Error sending error response to client")
+        finally:
+            with suppress(Exception):
+                conn.close()
+
+    def _extract_request(self, message: Any) -> dict[str, Any] | None:
+        """Normalize incoming message payloads into request dictionaries."""
+        if isinstance(message, dict) and "type" in message:
+            msg_type = message.get("type")
+            payload = message.get("payload", {})
+
+            if msg_type == "cancellation":
+                self._handle_cancellation(payload)
+                return None
+
+            if msg_type != "request":
+                logger.warning("Unknown message type: %s", msg_type)
+                return None
+
+            if not isinstance(payload, dict):
+                logger.warning("Invalid payload type: %s", type(payload))
+                return None
+
+            return payload
+
+        if not isinstance(message, dict):
+            logger.warning("Invalid request message: %s", type(message))
+            return None
+
+        return message
 
     def _process_request(self, request: dict[str, Any]) -> dict[str, Any]:
         """Process a single request and return a response."""
@@ -214,94 +238,86 @@ class Worker:
         method = request.get("method", "")
         body = request.get("body", {})
 
-        # Check if method is exposed
         if method not in _exposed_functions:
             return {"id": req_id, "ok": False, "error": f"Method '{method}' not found"}
 
-        # Create tracing context for this request
         with (
             self.tracing.trace_request(request) as span,
             self.cancellation_manager.track_request(req_id) as cancel_event,
         ):
             try:
-                # Call the exposed function
                 func = _exposed_functions[method]
 
-                # Check if function accepts cancel_event parameter
                 sig = inspect.signature(func)
                 if "cancel_event" in sig.parameters:
-                    # Function supports cancellation
                     result = func(body, cancel_event=cancel_event)
                 else:
-                    # Function doesn't support cancellation, just call it
                     result = func(body)
 
                 response = {"id": req_id, "ok": True, "body": result}
-
-                # Add trace headers to response
                 self.tracing.add_response_headers(response)
-
                 return response
 
-            except CancellationError as e:
-                # Request was cancelled
-                logger.info(f"Request {req_id} cancelled: {e.reason}")
-                return {"id": req_id, "ok": False, "error": f"Cancelled: {e.reason}"}
+            except CancellationError as exc:
+                logger.info("Request %s cancelled: %s", req_id, exc.reason)
+                return {"id": req_id, "ok": False, "error": f"Cancelled: {exc.reason}"}
 
-            except Exception as e:
-                # Capture the full traceback for debugging
-                tb = traceback.format_exc()
-                logger.exception("Error in method '%s': %s", method, tb)
+            except Exception as exc:
+                traceback_text = traceback.format_exc()
+                logger.exception("Error in method '%s': %s", method, traceback_text)
 
                 if span:
-                    # Record exception in span
-                    span.record_exception(e)
+                    span.record_exception(exc)
 
-                return {"id": req_id, "ok": False, "error": str(e)}
+                return {"id": req_id, "ok": False, "error": str(exc)}
 
     def _handle_cancellation(self, cancellation_msg: dict[str, Any]) -> None:
-        """Handle a cancellation message from Go.
-
-        Args:
-            cancellation_msg: Cancellation message with 'id' and 'reason' fields
-
-        """
+        """Handle a cancellation message from Go."""
         req_id = cancellation_msg.get("id", 0)
         reason = cancellation_msg.get("reason", "context cancelled")
-
-        logger.info(f"Received cancellation for request {req_id}: {reason}")
-
-        # Cancel the request
+        logger.info("Received cancellation for request %s: %s", req_id, reason)
         self.cancellation_manager.cancel_request(req_id, reason)
 
 
-def run_worker(socket_path: str | None = None, codec_type: str = "auto") -> None:
-    """Run the worker with the specified socket path.
-
-    Args:
-        socket_path: Path to the Unix domain socket.
-                    If not provided, uses environment variable PYPROC_SOCKET_PATH.
-        codec_type: Type of codec to use ("auto", "json", "orjson", "msgspec", "msgpack")
-                   "auto" will choose the fastest available codec.
-
-    """
+def run_worker(
+    socket_path: str | None = None,
+    codec_type: str = "auto",
+    concurrency: int | None = None,
+) -> None:
+    """Run the worker with the specified socket path."""
     if socket_path is None:
         socket_path = os.environ.get("PYPROC_SOCKET_PATH")
         if not socket_path:
             msg = "Socket path must be provided or set in PYPROC_SOCKET_PATH"
             raise ValueError(msg)
 
-    # Check for codec type from environment variable
     env_codec = os.environ.get("PYPROC_CODEC_TYPE")
     if env_codec:
         codec_type = env_codec
 
-    worker = Worker(socket_path, codec_type)
+    if concurrency is None:
+        env_concurrency = os.environ.get("PYPROC_WORKER_CONCURRENCY")
+        if env_concurrency:
+            try:
+                concurrency = int(env_concurrency)
+            except ValueError:
+                logger.warning(
+                    "Invalid PYPROC_WORKER_CONCURRENCY value: %s, using default 1",
+                    env_concurrency,
+                )
+                concurrency = 1
+        else:
+            concurrency = 1
+
+    if concurrency <= 0:
+        logger.warning("Invalid concurrency value %s, using default 1", concurrency)
+        concurrency = 1
+
+    worker = Worker(socket_path, codec_type, concurrency)
     worker.start()
 
 
-# Health check method (always available)
 @expose
-def health(_req):
+def health(_req: dict[str, Any]) -> dict[str, Any]:
     """Health check endpoint."""
     return {"status": "healthy", "pid": os.getpid()}


### PR DESCRIPTION
## Summary
Implements threading support for Python workers to efficiently handle IO-bound tasks, addressing Issue #17.

## Changes
- **Python Worker**: Added `ThreadPoolExecutor` support with configurable concurrency
- **Go Configuration**: Added `WorkerConcurrency` field to pass threading configuration
- **Examples**: Created comprehensive IO-bound demonstration
- **Documentation**: Updated README and design docs with threading guidance

## Motivation
As described in #17, single-threaded workers block on IO operations, limiting throughput for workloads involving network requests or database queries. This PR enables concurrent request handling within each worker process.

## Performance Impact
For IO-bound tasks with 1s network delay:
- **Before**: 8 sequential requests = 8 seconds
- **After**: 8 concurrent requests with 4 threads = ~2 seconds (4x speedup)

## Configuration
```go
WorkerConfig: pyproc.WorkerConfig{
    WorkerConcurrency: 4,  // Enable 4 threads per worker
}
```

## Testing
1. Run existing tests to verify backward compatibility:
   ```bash
   go test ./pkg/pyproc/...
   ```

2. Run the new IO-bound example:
   ```bash
   cd examples/io_bound
   go run main.go
   ```

3. Python lint checks pass:
   ```bash
   cd worker/python && ruff check .
   ```

## Backward Compatibility
- Default `WorkerConcurrency = 1` maintains single-threaded behavior
- No API changes required for existing code
- Threading only activated when explicitly configured

Closes #17