### PR TITLE
test: add unit tests for socket, connection, grpc, hmac

### DIFF
--- a/pkg/pyproc/connection_test.go
+++ b/pkg/pyproc/connection_test.go
@@ -1,0 +1,103 @@
+package pyproc
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestConnectToWorker_Success(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}()
+
+	conn, err := ConnectToWorker(socketPath, 5*time.Second)
+	if err != nil {
+		t.Fatalf("ConnectToWorker failed: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+}
+
+func TestConnectToWorker_Timeout(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "nonexistent.sock")
+
+	start := time.Now()
+	_, err := ConnectToWorker(socketPath, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected error for non-existent socket")
+	}
+
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("expected to wait at least 200ms, waited %v", elapsed)
+	}
+
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected to timeout around 200ms, waited %v", elapsed)
+	}
+}
+
+func TestSleepWithCtx_NormalCompletion(t *testing.T) {
+	ctx := context.Background()
+	start := time.Now()
+
+	err := sleepWithCtx(ctx, 50*time.Millisecond)
+
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if elapsed < 50*time.Millisecond {
+		t.Errorf("expected to sleep at least 50ms, slept %v", elapsed)
+	}
+}
+
+func TestSleepWithCtx_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := sleepWithCtx(ctx, 1*time.Second)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("expected context canceled error")
+	}
+
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("expected early exit on cancel, waited %v", elapsed)
+	}
+}
+
+func TestSleepWithCtx_ContextAlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepWithCtx(ctx, 1*time.Second)
+	if err == nil {
+		t.Error("expected context canceled error")
+	}
+}

--- a/pkg/pyproc/socket_hmac_test.go
+++ b/pkg/pyproc/socket_hmac_test.go
@@ -1,0 +1,204 @@
+package pyproc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewHMACAuth(t *testing.T) {
+	secret := []byte("test-secret-key")
+	auth := NewHMACAuth(secret)
+
+	if auth == nil {
+		t.Fatal("expected non-nil HMACAuth")
+	}
+	if !bytes.Equal(auth.secret, secret) {
+		t.Error("secret mismatch")
+	}
+}
+
+func TestGenerateSecret(t *testing.T) {
+	secret1, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret failed: %v", err)
+	}
+
+	if len(secret1) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(secret1))
+	}
+
+	secret2, err := GenerateSecret()
+	if err != nil {
+		t.Fatalf("GenerateSecret failed: %v", err)
+	}
+
+	if bytes.Equal(secret1, secret2) {
+		t.Error("generated secrets should be unique")
+	}
+}
+
+func TestSecretFromString(t *testing.T) {
+	secret := SecretFromString("my-password")
+
+	if len(secret) != 32 {
+		t.Errorf("expected 32 bytes (SHA256 output), got %d", len(secret))
+	}
+
+	secret2 := SecretFromString("my-password")
+	if !bytes.Equal(secret, secret2) {
+		t.Error("same input should produce same secret")
+	}
+
+	secret3 := SecretFromString("different-password")
+	if bytes.Equal(secret, secret3) {
+		t.Error("different input should produce different secret")
+	}
+}
+
+func TestSecretFromHex(t *testing.T) {
+	hexStr := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	secret, err := SecretFromHex(hexStr)
+	if err != nil {
+		t.Fatalf("SecretFromHex failed: %v", err)
+	}
+
+	if len(secret) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(secret))
+	}
+
+	expected, _ := hex.DecodeString(hexStr)
+	if !bytes.Equal(secret, expected) {
+		t.Error("decoded secret mismatch")
+	}
+}
+
+func TestSecretFromHex_InvalidHex(t *testing.T) {
+	_, err := SecretFromHex("not-valid-hex")
+	if err == nil {
+		t.Error("expected error for invalid hex")
+	}
+}
+
+func TestHMACAuthClientServer(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "hmac-test.sock")
+
+	secret := []byte("shared-secret-key-for-testing")
+	serverAuth := NewHMACAuth(secret)
+	clientAuth := NewHMACAuth(secret)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serverErr <- serverAuth.AuthenticateServer(conn)
+	}()
+
+	clientConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	err = clientAuth.AuthenticateClient(clientConn)
+	if err != nil {
+		t.Errorf("client authentication failed: %v", err)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Errorf("server authentication failed: %v", err)
+	}
+}
+
+func TestHMACAuthWrongSecret(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "w.sock")
+
+	serverAuth := NewHMACAuth([]byte("server-secret"))
+	clientAuth := NewHMACAuth([]byte("wrong-client-secret"))
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serverErr <- serverAuth.AuthenticateServer(conn)
+	}()
+
+	clientConn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	err = clientAuth.AuthenticateClient(clientConn)
+	if err == nil {
+		t.Error("expected authentication to fail with wrong secret")
+	}
+
+	if err := <-serverErr; err == nil {
+		t.Error("expected server to detect authentication failure")
+	}
+}
+
+func TestNewHMACListener(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "hmac-listener.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+
+	secret := []byte("test-secret")
+	hmacListener := NewHMACListener(listener, secret)
+
+	if hmacListener == nil {
+		t.Fatal("expected non-nil HMACListener")
+	}
+	if hmacListener.auth == nil {
+		t.Error("expected non-nil auth in HMACListener")
+	}
+
+	_ = hmacListener.Close()
+}
+
+func TestSecureConnIsAuthenticated(t *testing.T) {
+	conn := &SecureConn{
+		authenticated: true,
+	}
+
+	if !conn.IsAuthenticated() {
+		t.Error("expected IsAuthenticated to return true")
+	}
+
+	conn.authenticated = false
+	if conn.IsAuthenticated() {
+		t.Error("expected IsAuthenticated to return false")
+	}
+}

--- a/pkg/pyproc/socket_test.go
+++ b/pkg/pyproc/socket_test.go
@@ -1,0 +1,145 @@
+package pyproc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSocketManager(t *testing.T) {
+	cfg := SocketConfig{
+		Dir:         "/tmp/test-sockets",
+		Prefix:      "pyproc",
+		Permissions: 0o600,
+	}
+
+	sm := NewSocketManager(cfg)
+
+	if sm.dir != cfg.Dir {
+		t.Errorf("expected dir %s, got %s", cfg.Dir, sm.dir)
+	}
+	if sm.prefix != cfg.Prefix {
+		t.Errorf("expected prefix %s, got %s", cfg.Prefix, sm.prefix)
+	}
+	if sm.permissions != os.FileMode(cfg.Permissions) {
+		t.Errorf("expected permissions %o, got %o", cfg.Permissions, sm.permissions)
+	}
+}
+
+func TestGenerateSocketPath(t *testing.T) {
+	sm := &SocketManager{
+		dir:    "/tmp/sockets",
+		prefix: "test",
+	}
+
+	path := sm.GenerateSocketPath("worker-1")
+	expected := "/tmp/sockets/test-worker-1.sock"
+	if path != expected {
+		t.Errorf("expected %s, got %s", expected, path)
+	}
+}
+
+func TestCleanupSocket(t *testing.T) {
+	tmpDir := t.TempDir()
+	sm := &SocketManager{dir: tmpDir}
+
+	t.Run("socket does not exist", func(t *testing.T) {
+		nonExistentPath := filepath.Join(tmpDir, "nonexistent.sock")
+		err := sm.CleanupSocket(nonExistentPath)
+		if err != nil {
+			t.Errorf("expected no error for non-existent socket, got %v", err)
+		}
+	})
+
+	t.Run("socket exists and is removed", func(t *testing.T) {
+		socketPath := filepath.Join(tmpDir, "test.sock")
+		if err := os.WriteFile(socketPath, []byte{}, 0o600); err != nil {
+			t.Fatalf("failed to create test socket: %v", err)
+		}
+
+		err := sm.CleanupSocket(socketPath)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+			t.Error("socket file should have been removed")
+		}
+	})
+}
+
+func TestCleanupAllSockets(t *testing.T) {
+	tmpDir := t.TempDir()
+	sm := &SocketManager{
+		dir:    tmpDir,
+		prefix: "pyproc",
+	}
+
+	sockets := []string{
+		filepath.Join(tmpDir, "pyproc-worker1.sock"),
+		filepath.Join(tmpDir, "pyproc-worker2.sock"),
+		filepath.Join(tmpDir, "other-worker.sock"),
+	}
+	for _, s := range sockets {
+		if err := os.WriteFile(s, []byte{}, 0o600); err != nil {
+			t.Fatalf("failed to create socket %s: %v", s, err)
+		}
+	}
+
+	err := sm.CleanupAllSockets()
+	if err != nil {
+		t.Errorf("CleanupAllSockets failed: %v", err)
+	}
+
+	if _, err := os.Stat(sockets[0]); !os.IsNotExist(err) {
+		t.Error("pyproc-worker1.sock should have been removed")
+	}
+	if _, err := os.Stat(sockets[1]); !os.IsNotExist(err) {
+		t.Error("pyproc-worker2.sock should have been removed")
+	}
+	if _, err := os.Stat(sockets[2]); os.IsNotExist(err) {
+		t.Error("other-worker.sock should NOT have been removed")
+	}
+}
+
+func TestEnsureSocketDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketDir := filepath.Join(tmpDir, "nested", "sockets")
+	sm := &SocketManager{dir: socketDir}
+
+	err := sm.EnsureSocketDir()
+	if err != nil {
+		t.Fatalf("EnsureSocketDir failed: %v", err)
+	}
+
+	info, err := os.Stat(socketDir)
+	if err != nil {
+		t.Fatalf("failed to stat socket dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected socket dir to be a directory")
+	}
+}
+
+func TestSocketManager_SetSocketPermissions(t *testing.T) {
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "test.sock")
+	if err := os.WriteFile(socketPath, []byte{}, 0o644); err != nil {
+		t.Fatalf("failed to create test socket: %v", err)
+	}
+
+	sm := &SocketManager{permissions: 0o600}
+	err := sm.SetSocketPermissions(socketPath)
+	if err != nil {
+		t.Fatalf("SetSocketPermissions failed: %v", err)
+	}
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("failed to stat socket: %v", err)
+	}
+
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("expected permissions 0600, got %o", info.Mode().Perm())
+	}
+}

--- a/pkg/pyproc/transport_grpc_test.go
+++ b/pkg/pyproc/transport_grpc_test.go
@@ -1,0 +1,28 @@
+package pyproc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewGRPCTransport_NotImplemented(t *testing.T) {
+	cfg := TransportConfig{
+		Type:    "grpc",
+		Address: "localhost:50051",
+	}
+	logger := NewLogger(LoggingConfig{Level: "debug"})
+
+	transport, err := NewGRPCTransport(cfg, logger)
+
+	if transport != nil {
+		t.Error("expected nil transport for unimplemented gRPC")
+	}
+
+	if err == nil {
+		t.Fatal("expected error for unimplemented gRPC transport")
+	}
+
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("expected 'not yet implemented' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for SocketManager functions (NewSocketManager, GenerateSocketPath, CleanupSocket, CleanupAllSockets, EnsureSocketDir, SetSocketPermissions)
- Add unit tests for connection functions (ConnectToWorker, sleepWithCtx)
- Add unit test for NewGRPCTransport (not implemented error)
- Add unit tests for HMAC authentication (NewHMACAuth, GenerateSecret, SecretFromString, SecretFromHex, client/server auth)

## Test plan
- [x] All new tests pass locally
- [x] Existing tests not affected
- [x] Code formatted with gofmt