### PR TITLE
test: add error path tests for uds, pool, worker

### DIFF
--- a/pkg/pyproc/pool_error_test.go
+++ b/pkg/pyproc/pool_error_test.go
@@ -1,0 +1,188 @@
+package pyproc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewPool_ZeroWorkers(t *testing.T) {
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers: 0,
+		},
+	}
+
+	_, err := NewPool(opts, nil)
+	if err == nil {
+		t.Error("expected error for zero workers")
+	}
+}
+
+func TestNewPool_NegativeWorkers(t *testing.T) {
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers: -1,
+		},
+	}
+
+	_, err := NewPool(opts, nil)
+	if err == nil {
+		t.Error("expected error for negative workers")
+	}
+}
+
+func TestPoolCall_AfterShutdown(t *testing.T) {
+	requireUnixSocket(t)
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:     1,
+			MaxInFlight: 5,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath:   "/tmp/test-pool-shutdown-call.sock",
+			PythonExec:   "python3",
+			WorkerScript: "../../examples/basic/worker.py",
+			StartTimeout: 5 * time.Second,
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start failed: %v", err)
+	}
+
+	_ = pool.Shutdown(ctx)
+
+	input := map[string]int{"value": 42}
+	var output map[string]int
+	err = pool.Call(ctx, "predict", input, &output)
+	if err == nil {
+		t.Error("expected error when calling after shutdown")
+	}
+}
+
+func TestPoolCall_ContextCanceled(t *testing.T) {
+	requireUnixSocket(t)
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:     1,
+			MaxInFlight: 1,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath:   "/tmp/test-pool-cancel.sock",
+			PythonExec:   "python3",
+			WorkerScript: "../../examples/basic/worker.py",
+			StartTimeout: 5 * time.Second,
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+	defer func() { _ = pool.Shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start failed: %v", err)
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	input := map[string]int{"value": 42}
+	var output map[string]int
+	err = pool.Call(canceledCtx, "predict", input, &output)
+	if err == nil {
+		t.Error("expected error with canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Logf("got error: %v (may be acceptable)", err)
+	}
+}
+
+func TestPoolShutdown_Double(t *testing.T) {
+	requireUnixSocket(t)
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:     1,
+			MaxInFlight: 5,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath:   "/tmp/test-pool-double-shutdown.sock",
+			PythonExec:   "python3",
+			WorkerScript: "../../examples/basic/worker.py",
+			StartTimeout: 5 * time.Second,
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := pool.Start(ctx); err != nil {
+		t.Fatalf("pool.Start failed: %v", err)
+	}
+
+	err1 := pool.Shutdown(ctx)
+	err2 := pool.Shutdown(ctx)
+
+	if err1 != nil {
+		t.Errorf("first shutdown should succeed: %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("second shutdown should succeed (no-op): %v", err2)
+	}
+}
+
+func TestPool_DefaultMaxInFlight(t *testing.T) {
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:     1,
+			MaxInFlight: 0,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath: "/tmp/test.sock",
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+
+	if pool.opts.Config.MaxInFlight != 10 {
+		t.Errorf("expected default MaxInFlight 10, got %d", pool.opts.Config.MaxInFlight)
+	}
+}
+
+func TestPool_DefaultHealthInterval(t *testing.T) {
+	opts := PoolOptions{
+		Config: PoolConfig{
+			Workers:        1,
+			HealthInterval: 0,
+		},
+		WorkerConfig: WorkerConfig{
+			SocketPath: "/tmp/test.sock",
+		},
+	}
+
+	pool, err := NewPool(opts, nil)
+	if err != nil {
+		t.Fatalf("NewPool failed: %v", err)
+	}
+
+	expected := 30 * time.Second
+	if pool.opts.Config.HealthInterval != expected {
+		t.Errorf("expected default HealthInterval %v, got %v", expected, pool.opts.Config.HealthInterval)
+	}
+}

--- a/pkg/pyproc/transport_uds_test.go
+++ b/pkg/pyproc/transport_uds_test.go
@@ -1,0 +1,171 @@
+package pyproc
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/YuminosukeSato/pyproc/internal/protocol"
+)
+
+func TestNewUDSTransport_EmptyAddress(t *testing.T) {
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: "",
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	_, err := NewUDSTransport(cfg, logger)
+	if err == nil {
+		t.Error("expected error for empty address")
+	}
+}
+
+func TestNewUDSTransport_InvalidCodec(t *testing.T) {
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: "/tmp/test.sock",
+		Options: map[string]interface{}{
+			"codec": "invalid-codec",
+		},
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	_, err := NewUDSTransport(cfg, logger)
+	if err == nil {
+		t.Error("expected error for invalid codec")
+	}
+}
+
+func TestNewUDSTransport_NonExistentSocket(t *testing.T) {
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: "/tmp/nonexistent-socket-12345.sock",
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	_, err := NewUDSTransport(cfg, logger)
+	if err == nil {
+		t.Error("expected error for non-existent socket")
+	}
+}
+
+func TestUDSTransport_CallAfterClose(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "t.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}()
+
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: socketPath,
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	transport, err := NewUDSTransport(cfg, logger)
+	if err != nil {
+		t.Fatalf("failed to create transport: %v", err)
+	}
+
+	_ = transport.Close()
+
+	req, _ := protocol.NewRequest(1, "test", nil)
+	_, err = transport.Call(context.Background(), req)
+	if err == nil {
+		t.Error("expected error when calling after close")
+	}
+}
+
+func TestUDSTransport_Health(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "h.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+		_ = conn.Close()
+	}()
+
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: socketPath,
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	transport, err := NewUDSTransport(cfg, logger)
+	if err != nil {
+		t.Fatalf("failed to create transport: %v", err)
+	}
+
+	_ = transport.Close()
+
+	if transport.IsHealthy() {
+		t.Error("transport should not be healthy after close")
+	}
+}
+
+func TestUDSTransport_DoubleClose(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	socketPath := filepath.Join(tmpDir, "d.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}()
+
+	cfg := TransportConfig{
+		Type:    "uds",
+		Address: socketPath,
+	}
+	logger := NewLogger(LoggingConfig{Level: "error"})
+
+	transport, err := NewUDSTransport(cfg, logger)
+	if err != nil {
+		t.Fatalf("failed to create transport: %v", err)
+	}
+
+	err1 := transport.Close()
+	err2 := transport.Close()
+
+	if err1 != nil {
+		t.Errorf("first close should succeed: %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("second close should succeed (no-op): %v", err2)
+	}
+}

--- a/pkg/pyproc/worker_error_test.go
+++ b/pkg/pyproc/worker_error_test.go
@@ -1,0 +1,160 @@
+package pyproc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWorker_StopNotStarted(t *testing.T) {
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   "/tmp/test-stop-not-started.sock",
+		PythonExec:   "python3",
+		WorkerScript: "/nonexistent/script.py",
+		StartTimeout: 1 * time.Second,
+	}
+
+	worker := NewWorker(cfg, nil)
+
+	err := worker.Stop()
+	if err != nil {
+		t.Errorf("stopping a not-started worker should not error: %v", err)
+	}
+}
+
+func TestWorker_IsRunning_NotStarted(t *testing.T) {
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   "/tmp/test-isrunning.sock",
+		PythonExec:   "python3",
+		WorkerScript: "/nonexistent/script.py",
+		StartTimeout: 1 * time.Second,
+	}
+
+	worker := NewWorker(cfg, nil)
+
+	if worker.IsRunning() {
+		t.Error("worker should not be running before start")
+	}
+}
+
+func TestWorker_GetPID_NotStarted(t *testing.T) {
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   "/tmp/test-getpid.sock",
+		PythonExec:   "python3",
+		WorkerScript: "/nonexistent/script.py",
+		StartTimeout: 1 * time.Second,
+	}
+
+	worker := NewWorker(cfg, nil)
+
+	pid := worker.GetPID()
+	if pid != 0 {
+		t.Errorf("expected PID 0 for not-started worker, got %d", pid)
+	}
+}
+
+func TestWorker_IsHealthy_NotRunning(t *testing.T) {
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   "/tmp/test-healthy.sock",
+		PythonExec:   "python3",
+		WorkerScript: "/nonexistent/script.py",
+		StartTimeout: 1 * time.Second,
+	}
+
+	worker := NewWorker(cfg, nil)
+	ctx := context.Background()
+
+	if worker.IsHealthy(ctx) {
+		t.Error("worker should not be healthy when not running")
+	}
+}
+
+func TestWorker_DoubleStop(t *testing.T) {
+	requireUnixSocket(t)
+	tmpDir := t.TempDir()
+	workerScript := tmpDir + "/test_worker.py"
+	socketPath := tmpDir + "/t.sock"
+
+	pythonScript := `
+import sys
+import os
+project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(project_root, 'worker', 'python'))
+
+from pyproc_worker import expose, run_worker
+
+@expose
+def health(req):
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    run_worker("` + socketPath + `")
+`
+	if err := writeTestFile(workerScript, pythonScript); err != nil {
+		t.Fatalf("Failed to write worker script: %v", err)
+	}
+
+	projectRoot, _ := absPath("../..")
+	pythonPath := projectRoot + "/worker/python"
+
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   socketPath,
+		PythonExec:   "python3",
+		WorkerScript: workerScript,
+		StartTimeout: 5 * time.Second,
+		Env: map[string]string{
+			"PYTHONPATH": pythonPath,
+		},
+	}
+
+	ctx := context.Background()
+	worker := NewWorker(cfg, nil)
+
+	if err := worker.Start(ctx); err != nil {
+		t.Fatalf("Failed to start worker: %v", err)
+	}
+
+	err1 := worker.Stop()
+	err2 := worker.Stop()
+
+	if err1 != nil {
+		t.Errorf("first stop should succeed: %v", err1)
+	}
+	if err2 != nil {
+		t.Errorf("second stop should succeed (no-op): %v", err2)
+	}
+}
+
+func TestWorker_RestartNotStarted(t *testing.T) {
+	cfg := WorkerConfig{
+		ID:           "test-worker",
+		SocketPath:   "/tmp/test-restart.sock",
+		PythonExec:   "python3",
+		WorkerScript: "/nonexistent/script.py",
+		StartTimeout: 1 * time.Second,
+	}
+
+	worker := NewWorker(cfg, nil)
+	ctx := context.Background()
+
+	err := worker.Restart(ctx)
+	if err == nil {
+		_ = worker.Stop()
+		t.Error("expected restart to fail for non-started worker with invalid script")
+	}
+}
+
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func absPath(path string) (string, error) {
+	return filepath.Abs(path)
+}


### PR DESCRIPTION
## Summary
- Add error path tests for UDSTransport (empty address, invalid codec, non-existent socket, call after close, health after close, double close)
- Add error path tests for Pool (zero workers, negative workers, call after shutdown, context canceled, double shutdown, default values)
- Add error path tests for Worker (stop not started, is running not started, get PID not started, is healthy not running, double stop, restart not started)

## Test plan
- [x] All new tests pass locally
- [x] Existing tests not affected
- [x] Code formatted with gofmt