### PR TITLE
release: pyproc-worker 0.1.1 (PyPI)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,33 @@ jobs:
             sbom-python.cdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pyproc-worker/
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        working-directory: worker/python
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: worker/python/dist/

--- a/worker/python/pyproject.toml
+++ b/worker/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyproc-worker"
-version = "0.1.0"
+version = "0.1.1"
 authors = [{ name = "YuminosukeSato" }]
 description = "Python worker for pyproc - Call Python from Go without CGO"
 readme = "README.md"


### PR DESCRIPTION
# pyproc-worker 0.1.1 Release

Release Python package to PyPI with observability support.

## Changes

- **Version**: 0.1.0 → 0.1.1
- **New Feature**: W3C Trace Context extraction (`tracing.py`)
- **Compatible with**: pyproc v0.7.1 Go package

## What's New

### W3C Trace Context Support

```python
# Automatically extracts trace context from Go requests
from pyproc_worker.tracing import extract_trace_context

# Works with OpenTelemetry (optional dependency)
pip install pyproc-worker[telemetry]
```

### Optional Dependencies

- `orjson` (required): High-performance JSON codec
- `opentelemetry-api`, `opentelemetry-sdk` (optional): Tracing support
- `msgspec` (optional): MessagePack codec

### Backward Compatibility

✅ **No breaking changes**
- Existing code works without modification
- Tracing module works without OpenTelemetry installed (graceful degradation)

## Testing

- All existing tests pass
- New tracing tests added

## PyPI Release

After merge, publish to PyPI:

```bash
cd worker/python
uv build
uv publish
```

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>